### PR TITLE
FEATURE: Subscription Engine 1.3 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">=8.3",
-        "wwwision/subscription-engine": "~1.2.1",
+        "wwwision/subscription-engine": "^1",
         "psr/clock": "^1",
         "doctrine/dbal": "^3 || ^4"
     },

--- a/src/DoctrineSubscriptionStore.php
+++ b/src/DoctrineSubscriptionStore.php
@@ -59,13 +59,23 @@ final class DoctrineSubscriptionStore implements SubscriptionStore
         }
     }
 
+    public function findByCriteria(SubscriptionCriteria $criteria): Subscriptions
+    {
+        return $this->fetchByCriteria($criteria, false);
+    }
+
     public function findByCriteriaForUpdate(SubscriptionCriteria $criteria): Subscriptions
+    {
+        return $this->fetchByCriteria($criteria, true);
+    }
+
+    private function fetchByCriteria(SubscriptionCriteria $criteria, bool $forUpdate): Subscriptions
     {
         $queryBuilder = $this->dbal->createQueryBuilder()
             ->select('*')
             ->from($this->tableName)
             ->orderBy('id');
-        if (!$this->dbal->getDatabasePlatform() instanceof SQLitePlatform) {
+        if ($forUpdate && !$this->dbal->getDatabasePlatform() instanceof SQLitePlatform) {
             $queryBuilder->forUpdate();
         }
         if ($criteria->ids !== null) {

--- a/tests/DoctrineSubscriptionStoreTest.php
+++ b/tests/DoctrineSubscriptionStoreTest.php
@@ -212,6 +212,75 @@ final class DoctrineSubscriptionStoreTest extends TestCase
     }
 
     #[Test]
+    public function findByCriteriaReturnsNoneWhenStoreIsEmpty(): void
+    {
+        $this->store->setup();
+
+        self::assertSameSubscriptionIds([], $this->store->findByCriteria(SubscriptionCriteria::noConstraints()));
+    }
+
+    #[Test]
+    public function findByCriteriaReturnsSubscriptionsOrderedById(): void
+    {
+        $this->store->setup();
+        $this->store->add(Subscription::create('charlie', RunMode::FROM_BEGINNING, SubscriptionStatus::ACTIVE));
+        $this->store->add(Subscription::create('alpha', RunMode::FROM_BEGINNING, SubscriptionStatus::ACTIVE));
+        $this->store->add(Subscription::create('bravo', RunMode::FROM_BEGINNING, SubscriptionStatus::ACTIVE));
+
+        self::assertSameSubscriptionIds(['alpha', 'bravo', 'charlie'], $this->store->findByCriteria(SubscriptionCriteria::noConstraints()));
+    }
+
+    #[Test]
+    public function findByCriteriaFiltersByIds(): void
+    {
+        $this->store->setup();
+        $this->store->add(Subscription::create('foo', RunMode::FROM_BEGINNING, SubscriptionStatus::ACTIVE));
+        $this->store->add(Subscription::create('bar', RunMode::FROM_BEGINNING, SubscriptionStatus::ACTIVE));
+        $this->store->add(Subscription::create('baz', RunMode::FROM_BEGINNING, SubscriptionStatus::ACTIVE));
+
+        $result = $this->store->findByCriteria(SubscriptionCriteria::create(ids: ['foo', 'baz']));
+        self::assertSameSubscriptionIds(['baz', 'foo'], $result);
+    }
+
+    #[Test]
+    public function findByCriteriaFiltersByStatus(): void
+    {
+        $this->store->setup();
+        $this->store->add(Subscription::create('active-1', RunMode::FROM_BEGINNING, SubscriptionStatus::ACTIVE));
+        $this->store->add(Subscription::create('booting-1', RunMode::FROM_BEGINNING, SubscriptionStatus::BOOTING));
+        $this->store->add(Subscription::create('active-2', RunMode::FROM_BEGINNING, SubscriptionStatus::ACTIVE));
+
+        $result = $this->store->findByCriteria(SubscriptionCriteria::create(status: [SubscriptionStatus::ACTIVE]));
+        self::assertSameSubscriptionIds(['active-1', 'active-2'], $result);
+    }
+
+    #[Test]
+    public function findByCriteriaCombinesIdAndStatusConstraints(): void
+    {
+        $this->store->setup();
+        $this->store->add(Subscription::create('foo', RunMode::FROM_BEGINNING, SubscriptionStatus::ACTIVE));
+        $this->store->add(Subscription::create('bar', RunMode::FROM_BEGINNING, SubscriptionStatus::BOOTING));
+        $this->store->add(Subscription::create('baz', RunMode::FROM_BEGINNING, SubscriptionStatus::ACTIVE));
+
+        $result = $this->store->findByCriteria(SubscriptionCriteria::create(ids: ['foo', 'bar'], status: [SubscriptionStatus::ACTIVE]));
+        self::assertSameSubscriptionIds(['foo'], $result);
+    }
+
+    #[Test]
+    public function findByCriteriaAndFindByCriteriaForUpdateReturnTheSameResult(): void
+    {
+        $this->store->setup();
+        $this->store->add(Subscription::create('foo', RunMode::FROM_BEGINNING, SubscriptionStatus::ACTIVE));
+        $this->store->add(Subscription::create('bar', RunMode::FROM_BEGINNING, SubscriptionStatus::BOOTING));
+
+        $criteria = SubscriptionCriteria::create(status: [SubscriptionStatus::BOOTING]);
+        self::assertSameSubscriptionIds(
+            $this->store->findByCriteriaForUpdate($criteria)->map(static fn(Subscription $s): string => $s->id->value),
+            $this->store->findByCriteria($criteria),
+        );
+    }
+
+    #[Test]
     public function transactionCommitPersistsChanges(): void
     {
         $this->store->setup();


### PR DESCRIPTION
The `wwwision/subscription-engine` `SubscriptionStore` interface (>=1.3) requires a non-locking `findByCriteria()` alongside the existing `findByCriteriaForUpdate()`. Implement it by extracting the shared query logic into a private `fetchByCriteria()` that only applies `forUpdate()` for the locking variant.

Also widen the version constraint to `^1` and add unit tests for `DoctrineSubscriptionStore` (setup, add/update, error round-trip, criteria filtering and both find methods) running against an in-memory SQLite connection.